### PR TITLE
Handle optional era in practice questions

### DIFF
--- a/main.js
+++ b/main.js
@@ -781,7 +781,7 @@ function generatePractice() {
         <div class="mb-4">
           <p class="font-semibold">${idx + 1}. ${q.question}</p>
           <input type="text" class="practice-input w-full p-2 mt-1 border rounded" data-answer="${q.answer.replace(/"/g, '&quot;')}">
-          <p class="text-xs text-gray-500 mt-1">난이도: ${q.difficulty} | 태그: ${q.tags.join(", ")} | 시대: ${q.era} | 스킬: ${q.skills.join(", ")}</p>
+          <p class="text-xs text-gray-500 mt-1">난이도: ${q.difficulty} | 태그: ${q.tags.join(", ")}${q.era ? ` | 시대: ${q.era}` : ""} | 스킬: ${q.skills.join(", ")}</p>
           <p class="result text-sm mt-1 hidden"></p>
         </div>`
       )
@@ -824,7 +824,7 @@ function createPracticeQuestions(count = 5) {
     answer: (item.answer_short || item.a).trim(),
     difficulty: levels[Math.floor(Math.random() * levels.length)],
     tags: item.tags || [item.category],
-    era: item.era || "N/A",
+    ...(item.era ? { era: item.era } : {}),
     skills: ["concept"],
   }));
 }


### PR DESCRIPTION
## Summary
- Omit era metadata in practice questions when not provided.
- Only attach era property when source data includes it.

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a2307f2c83308f4e0ac3d56d4138