### PR TITLE
Refine practice questions to use category-based sampling

### DIFF
--- a/main.js
+++ b/main.js
@@ -813,15 +813,37 @@ function generatePractice() {
   });
 }
 
-function createPracticeQuestions(count = 5) {
+function createPracticeQuestions(count = 4) {
+  const mechanismCategories = ["structure", "exposure", "lens", "digital", "film", "lighting"];
   const flattened = Object.entries(photographyData).flatMap(([category, arr]) =>
     arr.map((item) => ({ ...item, category })),
   );
-  const selected = [...flattened].sort(() => 0.5 - Math.random()).slice(0, count);
+  const pickRandom = (arr, n) => [...arr].sort(() => Math.random() - 0.5).slice(0, Math.min(n, arr.length));
+  const hasTag = (item, regex) => Array.isArray(item.tags) && item.tags.some((t) => regex.test(t));
+  const mechanisms = pickRandom(flattened.filter((item) => mechanismCategories.includes(item.category)), 2);
+  const photographers = pickRandom(
+    flattened.filter((item) => ["history", "tags"].includes(item.category) && hasTag(item, /(person|photographer|인물|인명)/i)),
+    1,
+  );
+  const oral = pickRandom(
+    flattened.filter((item) =>
+      (!mechanismCategories.includes(item.category) && item.category !== "history") ||
+      (item.category === "history" && hasTag(item, /(concept|개념)/i)),
+    ),
+    1,
+  );
+  let selected = [...mechanisms, ...photographers, ...oral];
+  if (selected.length < count) {
+    selected = selected.concat(
+      pickRandom(flattened.filter((item) => !selected.includes(item)), count - selected.length),
+    );
+  } else if (selected.length > count) {
+    selected = pickRandom(selected, count);
+  }
   const levels = ["easy", "medium", "hard"];
   return selected.map((item) => ({
     question: `${item.q}의 정의는?`,
-    answer: (item.answer_short || item.a).trim(),
+    answer: (item.answer_short || item.a || "").trim(),
     difficulty: levels[Math.floor(Math.random() * levels.length)],
     tags: item.tags || [item.category],
     era: item.era || "N/A",


### PR DESCRIPTION
## Summary
- sample practice questions by category: 2 mechanism, 1 photographer, 1 concept
- default to four questions and merge selections into existing format

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c2a2378d3c8330a87fdb65b667dd96