### PR TITLE
feat: use fuzzy scoring for practice

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,7 @@
     </div>
 
     <script src="photographyData.js"></script>
+    <script src="scoring.js"></script>
     <script src="main.js"></script>
   </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -506,14 +506,11 @@ function generatePractice() {
             return;
         }
         modalBody.querySelectorAll(".practice-input").forEach(input => {
-            const userAnswer = input.value.trim().toLowerCase();
-            const correctAnswer = input.dataset.answer.toLowerCase();
-            const normalize = (str) => str.split(/[^\p{L}\p{N}]+/u).filter(w => w.length >= 2);
-            const userWords = normalize(userAnswer);
-            const answerWords = normalize(correctAnswer);
-            const matchCount = answerWords.filter(w => userWords.includes(w)).length;
-            const ratio = answerWords.length ? matchCount / answerWords.length : 0;
-            const score = ratio === 1 ? 5 : ratio >= 0.75 ? 4 : ratio >= 0.5 ? 3 : ratio >= 0.25 ? 2 : 1;
+            const userAnswer = input.value;
+            const correctAnswer = input.dataset.answer;
+            const score = typeof calculateScore === 'function'
+                ? calculateScore(userAnswer, correctAnswer)
+                : 1;
             const resultEl = input.parentElement.querySelector(".result");
             resultEl.classList.remove("text-green-600", "text-red-600");
             const highScore = score >= 4;

--- a/scoring.js
+++ b/scoring.js
@@ -1,0 +1,66 @@
+const synonyms = {
+    photograph: ['photo', 'picture', 'image'],
+    camera: ['cam']
+};
+
+function normalize(str) {
+    return str
+        .toLowerCase()
+        .trim()
+        .replace(/[^\p{L}\p{N}\s]/gu, '');
+}
+
+function applySynonyms(words) {
+    return words.map(word => {
+        for (const [canonical, list] of Object.entries(synonyms)) {
+            if (word === canonical || list.includes(word)) {
+                return canonical;
+            }
+        }
+        return word;
+    });
+}
+
+function levenshtein(a, b) {
+    const alen = a.length;
+    const blen = b.length;
+    const dp = Array.from({ length: alen + 1 }, () => new Array(blen + 1).fill(0));
+    for (let i = 0; i <= alen; i++) dp[i][0] = i;
+    for (let j = 0; j <= blen; j++) dp[0][j] = j;
+    for (let i = 1; i <= alen; i++) {
+        for (let j = 1; j <= blen; j++) {
+            const cost = a[i - 1] === b[j - 1] ? 0 : 1;
+            dp[i][j] = Math.min(
+                dp[i - 1][j] + 1,
+                dp[i][j - 1] + 1,
+                dp[i - 1][j - 1] + cost
+            );
+        }
+    }
+    return dp[alen][blen];
+}
+
+function calculateScore(userAnswer, correctAnswer) {
+    const userNorm = applySynonyms(normalize(userAnswer).split(/\s+/)).join(' ');
+    const correctNorm = applySynonyms(normalize(correctAnswer).split(/\s+/)).join(' ');
+    const distance = levenshtein(userNorm, correctNorm);
+    const maxLen = Math.max(userNorm.length, correctNorm.length);
+    const similarity = maxLen === 0 ? 0 : 1 - distance / maxLen;
+    return similarity >= 0.9
+        ? 5
+        : similarity >= 0.75
+        ? 4
+        : similarity >= 0.5
+        ? 3
+        : similarity >= 0.25
+        ? 2
+        : 1;
+}
+
+if (typeof module !== 'undefined') {
+    module.exports = { calculateScore };
+}
+
+if (typeof window !== 'undefined') {
+    window.calculateScore = calculateScore;
+}

--- a/test.js
+++ b/test.js
@@ -1,9 +1,17 @@
 const assert = require('assert');
 const data = require('./photographyData.js');
+const { calculateScore } = require('./scoring.js');
 
 assert.ok(
   data.exposure.some((item) => item.q === '존 시스템 (Zone System)'),
-  'Zone System entry should exist in exposure array'
+  'Zone System entry should exist in exposure array',
 );
+
+assert.strictEqual(calculateScore('Zone System', 'Zone System'), 5);
+assert.ok(calculateScore('zone systm', 'Zone System') >= 4);
+assert.ok(calculateScore('photo', 'photograph') >= 4);
+const partial = calculateScore('Zone', 'Zone System');
+assert.ok(partial >= 2 && partial <= 3);
+assert.strictEqual(calculateScore('aperture', 'banana'), 1);
 
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- Add fuzzy scoring with Levenshtein distance and simple synonyms
- Integrate new scoring into practice grading and load via scoring.js
- Expand tests to cover exact, near, partial, and wrong answers

## Testing
- `node test.js`


------
https://chatgpt.com/codex/tasks/task_e_68c43bb819208330906b8654610dfb92