### PR TITLE
feat: add practice question filters

### DIFF
--- a/index.html
+++ b/index.html
@@ -128,6 +128,26 @@
           >
             ✨ AI 퀴즈 생성
           </button>
+          <div id="practiceFilters" class="mt-2">
+            <label for="practiceCategory" class="block text-sm mb-1">카테고리</label>
+            <select id="practiceCategory" class="w-full p-2 border rounded mb-2">
+              <option value="">전체</option>
+              <option value="structure">카메라 구조와 원리</option>
+              <option value="exposure">노출</option>
+              <option value="lens">렌즈와 광학</option>
+              <option value="digital">디지털</option>
+              <option value="film">필름 현상 인화</option>
+              <option value="lighting">조명과 필터</option>
+              <option value="history">사진사 & 사조</option>
+            </select>
+            <label for="practiceDifficulty" class="block text-sm mb-1">난이도</label>
+            <select id="practiceDifficulty" class="w-full p-2 border rounded">
+              <option value="">전체</option>
+              <option value="easy">쉬움</option>
+              <option value="medium">보통</option>
+              <option value="hard">어려움</option>
+            </select>
+          </div>
           <button
             id="practiceBtn"
             class="w-full bg-green-700 text-white font-bold py-3 px-4 rounded-lg hover:bg-green-800 transition-colors mt-2"

--- a/main.js
+++ b/main.js
@@ -484,7 +484,12 @@ async function generateQuiz(quizCount) {
 }
 
 function generatePractice() {
-    const questions = createPracticeQuestions();
+    const categoryEl = document.getElementById("practiceCategory");
+    const difficultyEl = document.getElementById("practiceDifficulty");
+    const filters = {};
+    if (categoryEl && categoryEl.value) filters.categories = [categoryEl.value];
+    if (difficultyEl && difficultyEl.value) filters.difficulties = [difficultyEl.value];
+    const questions = createPracticeQuestions(4, filters);
     showModal('실전 연습');
     const html = questions.map((q, idx) => {
         const difficultyMap = { easy: "🟢", medium: "🟡", hard: "🔴" };
@@ -527,18 +532,26 @@ function generatePractice() {
     });
 }
 
-function createPracticeQuestions(count = 4) {
-    const flattened = Object.entries(photographyData).flatMap(([category, arr]) =>
-        arr.map(item => ({ ...item, category }))
-    );
-    const pickRandom = (arr, n) => [...arr].sort(() => Math.random() - 0.5).slice(0, Math.min(n, arr.length));
+function createPracticeQuestions(count = 4, filters = {}) {
+    const { categories = [], difficulties = [] } = filters;
+    const flattened = Object.entries(photographyData)
+        .flatMap(([category, arr]) =>
+            arr.map(item => {
+                const starCount = ((item.a || "").match(/★/g) || []).length;
+                const difficulty = starCount >= 3 ? "hard" : starCount === 2 ? "medium" : "easy";
+                return { ...item, category, difficulty };
+            })
+        )
+        .filter(item =>
+            (categories.length === 0 || categories.includes(item.category)) &&
+            (difficulties.length === 0 || difficulties.includes(item.difficulty))
+        );
     const selected = pickRandom(flattened, count);
-    const levels = ["easy", "medium", "hard"];
     const endings = ["에 대해 설명하세요.", "에 대해 말해보세요."];
     return selected.map(item => ({
         question: `${item.q}${endings[Math.floor(Math.random() * endings.length)]}`,
-        answer: (item.answer_short || item.a || "").trim(),
-        difficulty: levels[Math.floor(Math.random() * levels.length)],
+        answer: (item.answer_short || item.a || "").replace(/\s*[★☆]+/g, "").trim(),
+        difficulty: item.difficulty,
         ...(item.era ? { era: item.era } : {}),
     }));
 }


### PR DESCRIPTION
## Summary
- add category and difficulty selectors near practice launch button
- allow `createPracticeQuestions` to filter by selected category and difficulty
- pass chosen filters from UI to practice question generation
- reuse global `pickRandom` to avoid duplicate definitions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c43bb75ecc8330a59700a1c193a071