### PR TITLE
Add practice score feedback messaging

### DIFF
--- a/main.js
+++ b/main.js
@@ -533,7 +533,13 @@ function generatePractice() {
         summary.id = 'practiceSummary';
         summary.className = 'p-3 bg-gray-100 rounded mt-2 text-sm';
         const maxScore = inputs.length * 5;
-        summary.innerHTML = `<p>총점: ${total}/${maxScore}</p><p>오답: ${wrong.length ? wrong.join(', ') : '없음'}</p>`;
+        const percentage = maxScore ? (total / maxScore) * 100 : 0;
+        const message = typeof getPracticeMessage === 'function'
+            ? getPracticeMessage(percentage)
+            : '';
+        summary.innerHTML = `<p>총점: ${total}/${maxScore} (${Math.round(percentage)}%)</p>` +
+            (message ? `<p>${message}</p>` : '') +
+            `<p>오답: ${wrong.length ? wrong.join(', ') : '없음'}</p>`;
         gradeBtn.parentElement.insertBefore(summary, gradeBtn);
         if (wrong.length) {
             const reviewBtn = document.createElement('button');

--- a/scoring.js
+++ b/scoring.js
@@ -58,10 +58,18 @@ function calculateScore(userAnswer, correctAnswer) {
         : 1;
 }
 
+function getPracticeMessage(percentage) {
+    if (percentage >= 90) return "대단해요!";
+    if (percentage >= 70) return "좋은 성과예요!";
+    if (percentage >= 50) return "조금만 더 힘내요!";
+    return "시작이 반이에요!";
+}
+
 if (typeof module !== 'undefined') {
-    module.exports = { calculateScore };
+    module.exports = { calculateScore, getPracticeMessage };
 }
 
 if (typeof window !== 'undefined') {
     window.calculateScore = calculateScore;
+    window.getPracticeMessage = getPracticeMessage;
 }

--- a/test.js
+++ b/test.js
@@ -1,6 +1,6 @@
 const assert = require('assert');
 const data = require('./photographyData.js');
-const { calculateScore } = require('./scoring.js');
+const { calculateScore, getPracticeMessage } = require('./scoring.js');
 
 assert.ok(
   data.exposure.some((item) => item.q === '존 시스템 (Zone System)'),
@@ -24,5 +24,11 @@ assert.ok(
 // fuzzy matching and synonyms
 assert.ok(calculateScore('camra', 'camera') >= 4);
 assert.ok(calculateScore('af', 'autofocus') >= 4);
+
+// practice message mapping
+assert.strictEqual(getPracticeMessage(95), '대단해요!');
+assert.strictEqual(getPracticeMessage(75), '좋은 성과예요!');
+assert.strictEqual(getPracticeMessage(55), '조금만 더 힘내요!');
+assert.strictEqual(getPracticeMessage(30), '시작이 반이에요!');
 
 console.log('Tests passed');


### PR DESCRIPTION
## Summary
- compute score percentage in practice grading and display matching motivational message
- provide message selection helper for reuse and testing
- test feedback message logic across score ranges

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c43e9d1a7083308c2da9e2aebbb7c9