### PR TITLE
Fix Gemini payload role for content generation

### DIFF
--- a/main.js
+++ b/main.js
@@ -401,7 +401,7 @@ function callGemini(prompt, useSchema = false, title = "AI 응답 생성 중") {
             let didTimeout = false;
             try {
             const payload = {
-                contents: [{ parts: [{ text: prompt }] }],
+                contents: [{ role: "user", parts: [{ text: prompt }] }],
                 generationConfig: {},
             };
             if (useSchema) {


### PR DESCRIPTION
## Summary
- add explicit user role to Gemini content requests so API accepts payloads

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68cbc09648d48330859c075f000b7c3a